### PR TITLE
Backport security fixes to `patched-DCMTK-3.6.6_20210115`

### DIFF
--- a/dcmdata/libsrc/dcfilefo.cc
+++ b/dcmdata/libsrc/dcfilefo.cc
@@ -736,6 +736,9 @@ OFCondition DcmFileFormat::readUntilTag(DcmInputStream &inStream,
                 errorFlag = metaInfo->read(inStream, EXS_Unknown, glenc, maxReadLength);
             }
 
+            // bail out if the meta-header is still incomplete or an error occured
+            if (errorFlag.bad()) return errorFlag;
+
             // determine xfer from tag (0002,0010) in the meta header
             newxfer = lookForXfer(metaInfo);
             if ((FileReadMode == ERM_fileOnly) || (FileReadMode == ERM_metaOnly))

--- a/dcmdata/libsrc/dcitem.cc
+++ b/dcmdata/libsrc/dcitem.cc
@@ -1463,7 +1463,11 @@ OFCondition DcmItem::readUntilTag(DcmInputStream & inStream,
                 /* tag and length (and possibly VR) information as well as maybe some data */
                 /* data value information. We need to continue reading the data value */
                 /* information for this particular element. */
-                errorFlag = elementList->get()->read(inStream, xfer, glenc, maxReadLength);
+                DcmObject *dO = elementList->get();
+                if (dO)
+                  errorFlag = dO->read(inStream, xfer, glenc, maxReadLength);
+                  else errorFlag = EC_InternalError; // should never happen
+
                 /* if reading was successful, we read the entire information */
                 /* for this element; hence lastElementComplete is true */
                 if (errorFlag.good())

--- a/dcmnet/apps/movescu.cc
+++ b/dcmnet/apps/movescu.cc
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (C) 1994-2020, OFFIS e.V.
+ *  Copyright (C) 1994-2022, OFFIS e.V.
  *  All rights reserved.  See COPYRIGHT file for details.
  *
  *  This software and supporting documentation were developed by
@@ -1431,6 +1431,7 @@ static OFCondition storeSCP(
         sprintf(imageFileName, "%s.%s",
             dcmSOPClassUIDToModality(req->AffectedSOPClassUID),
             req->AffectedSOPInstanceUID);
+        OFStandard::sanitizeFilename(imageFileName);
     }
 
     OFString temp_str;

--- a/dcmnet/apps/storescp.cc
+++ b/dcmnet/apps/storescp.cc
@@ -1857,12 +1857,14 @@ storeSCPCallback(
               if (!subdirectoryName.empty())
                 subdirectoryName += '_';
               subdirectoryName += currentStudyInstanceUID;
+              OFStandard::sanitizeFilename(subdirectoryName);
               break;
             case ESM_PatientName:
               // pattern: "[Patient's Name]_[YYYYMMDD]_[HHMMSSMMM]"
               subdirectoryName = currentPatientName;
               subdirectoryName += '_';
               subdirectoryName += timestamp;
+              OFStandard::sanitizeFilename(subdirectoryName);
               break;
             case ESM_None:
               break;
@@ -2062,9 +2064,11 @@ static OFCondition storeSCP(
     }
     else
     {
-      // don't create new UID, use the study instance UID as found in object
+      // Use the SOP instance UID as found in the C-STORE request message as part of the filename
+      OFString uid = req->AffectedSOPInstanceUID;
+      OFStandard::sanitizeFilename(uid);
       sprintf(imageFileName, "%s%c%s.%s%s", opt_outputDirectory.c_str(), PATH_SEPARATOR, dcmSOPClassUIDToModality(req->AffectedSOPClassUID, "UNKNOWN"),
-        req->AffectedSOPInstanceUID, opt_fileNameExtension.c_str());
+        uid.c_str(), opt_fileNameExtension.c_str());
     }
   }
 

--- a/dcmnet/libsrc/dstorscp.cc
+++ b/dcmnet/libsrc/dstorscp.cc
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (C) 2013-2017, OFFIS e.V.
+ *  Copyright (C) 2013-2022, OFFIS e.V.
  *  All rights reserved.  See COPYRIGHT file for details.
  *
  *  This software and supporting documentation were developed by
@@ -423,6 +423,7 @@ OFCondition DcmStorageSCP::generateDirAndFilename(OFString &filename,
                     generatedFileName = tmpString;
                     OFSTRINGSTREAM_FREESTR(tmpString);
                     // combine the generated file name with the directory name
+                    OFStandard::sanitizeFilename(generatedFileName);
                     OFStandard::combineDirAndFilename(filename, directoryName, generatedFileName);
                 }
                 break;
@@ -439,6 +440,7 @@ OFCondition DcmStorageSCP::generateDirAndFilename(OFString &filename,
                 generatedFileName = tmpString;
                 OFSTRINGSTREAM_FREESTR(tmpString);
                 // combine the generated file name with the directory name
+                OFStandard::sanitizeFilename(generatedFileName);
                 OFStandard::combineDirAndFilename(filename, directoryName, generatedFileName);
                 break;
             }
@@ -467,6 +469,7 @@ OFCondition DcmStorageSCP::generateDirAndFilename(OFString &filename,
                     generatedFileName = tmpString;
                     OFSTRINGSTREAM_FREESTR(tmpString);
                     // combine the generated file name
+                    OFStandard::sanitizeFilename(generatedFileName);
                     OFStandard::combineDirAndFilename(filename, directoryName, generatedFileName);
                 } else
                     status = EC_CouldNotGenerateFilename;

--- a/dcmnet/libsrc/scu.cc
+++ b/dcmnet/libsrc/scu.cc
@@ -1417,6 +1417,7 @@ OFString DcmSCU::createStorageFilename(DcmDataset* dataset)
     OFString name = dcmSOPClassUIDToModality(sopClassUID.c_str(), "UNKNOWN");
     name += ".";
     name += sopInstanceUID;
+    OFStandard::sanitizeFilename(name);
     OFString returnStr;
     OFStandard::combineDirAndFilename(returnStr, m_storageDir, name, OFTrue);
     return returnStr;

--- a/ofstd/include/dcmtk/ofstd/ofstd.h
+++ b/ofstd/include/dcmtk/ofstd/ofstd.h
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (C) 2000-2019, OFFIS e.V.
+ *  Copyright (C) 2000-2022, OFFIS e.V.
  *  All rights reserved.  See COPYRIGHT file for details.
  *
  *  This software and supporting documentation were developed by
@@ -1150,6 +1150,22 @@ class DCMTK_OFSTD_EXPORT OFStandard
      *  @return the last error code as OFerror_code object.
      */
     static OFerror_code getLastNetworkErrorCode();
+
+    /** sanitize a filename (NOT a path name!) by replacing all path
+     *  separators with underscores. This avoids possible path traversal
+     *  vulnerabilities if malformed data read from file or received over
+     *  a network is used as part of a filename.
+     *  @param fname filename to be sanitized
+     */
+    static void sanitizeFilename(OFString& fname);
+
+    /** sanitize a filename (NOT a path name!) by replacing all path
+     *  separators with underscores. This avoids possible path traversal
+     *  vulnerabilities if malformed data read from file or received over
+     *  a network is used as part of a filename.
+     *  @param fname filename to be sanitized
+     */
+    static void sanitizeFilename(char *fname);
 
  private:
 

--- a/ofstd/libsrc/offname.cc
+++ b/ofstd/libsrc/offname.cc
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (C) 1997-2018, OFFIS e.V.
+ *  Copyright (C) 1997-2022, OFFIS e.V.
  *  All rights reserved.  See COPYRIGHT file for details.
  *
  *  This software and supporting documentation were developed by
@@ -75,17 +75,22 @@ OFBool OFFilenameCreator::makeFilename(unsigned int &seed, const char *dir, cons
   {
     // create filename
     filename.clear();
-    if (dir)
-    {
-      filename = dir;
-      filename += PATH_SEPARATOR;
-    }
-    if (prefix) filename += prefix;
+    if (prefix) filename = prefix;
     addLongToString(creation_time, filename);
     // on some systems OFrand_r may produce only 16-bit random numbers.
     // To be on the safe side, we use two random numbers for the upper and the lower 16 bits.
     addLongToString((((OFrand_r(seed) & 0xFFFF) << 16) | (OFrand_r(seed) & 0xFFFF)), filename);
     if (postfix) filename += postfix;
+
+    OFStandard::sanitizeFilename(filename);
+
+    if (dir)
+    {
+      OFString dirname = dir;
+      dirname += PATH_SEPARATOR;
+      dirname += filename;
+      filename = dirname;
+    }
 
     // check if filename exists
     stat_result = stat(filename.c_str(), &stat_buf);

--- a/ofstd/libsrc/ofstd.cc
+++ b/ofstd/libsrc/ofstd.cc
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (C) 2001-2020, OFFIS e.V.
+ *  Copyright (C) 2001-2022, OFFIS e.V.
  *  All rights reserved.  See COPYRIGHT file for details.
  *
  *  This software and supporting documentation were developed by
@@ -3136,6 +3136,39 @@ OFerror_code OFStandard::getLastNetworkErrorCode()
     return OFerror_code( errno, OFsystem_category() );
 #endif
 }
+
+
+void OFStandard::sanitizeFilename(OFString& fname)
+{
+  size_t len = fname.length();
+  for (size_t i=0; i<len; ++i)
+  {
+#ifdef _WIN32
+        if ((fname[i] == PATH_SEPARATOR)||(fname[i] == '/')) fname[i] = '_';
+#else
+        if (fname[i] == PATH_SEPARATOR) fname[i] = '_';
+#endif
+  }
+}
+
+
+void OFStandard::sanitizeFilename(char *fname)
+{
+  if (fname)
+  {
+    char *c = fname;
+    while (*c)
+    {
+#ifdef _WIN32
+      if ((*c == PATH_SEPARATOR)||(*c == '/')) *c = '_';
+#else
+      if (*c == PATH_SEPARATOR) *c = '_';
+#endif
+      ++c;
+    }
+  }
+}
+
 
 // black magic:
 // The C++ standard says that std::in_place should not be called as a function,


### PR DESCRIPTION
Backport security fixes from the following post https://forum.dcmtk.org/viewtopic.php?t=5192 because of the folowing CVE: [CVE-2022-2119](https://www.cvedetails.com/cve/CVE-2022-2119/) and [CVE-2022-2120](https://www.cvedetails.com/cve/CVE-2022-2120/)